### PR TITLE
feat: astro-font - optimize fonts & prevent CLS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
         "@tailwindcss/typography": "^0.5.10",
         "astro": "^4.3.2",
+        "astro-font": "^0.0.77",
         "katex": "^0.16.9",
         "rehype-katex": "^7.0.0",
         "remark-math": "^6.0.0",
@@ -2409,6 +2410,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/astro-font": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/astro-font/-/astro-font-0.0.77.tgz",
+      "integrity": "sha512-dh5TX2uxwqdFq15DF9cbRZgEdE9o8q522MP6xZYs+rnd3dexfDsIJMeEIDNVO7rkRxwJ7sphhCqTmdWvUJaiDg=="
     },
     "node_modules/astrojs-compiler-sync": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@tailwindcss/typography": "^0.5.10",
     "astro": "^4.3.2",
+    "astro-font": "^0.0.77",
     "katex": "^0.16.9",
     "rehype-katex": "^7.0.0",
     "remark-math": "^6.0.0",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -3,7 +3,7 @@ import type { SiteProps } from '@/types';
 import GTag from '@/components/GoogleTag.astro';
 import * as Config from '@/config';
 import '../styles/base.css';
-
+import { AstroFont } from 'astro-font';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import 'katex/dist/katex.css';
 
@@ -31,7 +31,19 @@ const { description, lang, noindex, pageTitle } = Astro.props;
     <meta property="og:image" content={Config.site.root + Config.site.image} />
     <title>{pageTitle}</title>
     <link href="/feed.xml" title="RSS Feed" type="application/rss+xml" rel="alternate" />
-    <link href="https://fonts.googleapis.com/css?family=Raleway:400,600&display=swap" rel="stylesheet" />
+    <AstroFont
+      config={[
+        {
+          src: [],
+          preload: false,
+          display: "swap",
+          name: "Raleway",
+          selector: "body",
+          fallback: "sans-serif",
+          googleFontsURL: 'https://fonts.googleapis.com/css?family=Raleway:400,600',
+        },
+      ]}
+    />
   </head>
   <body>
     <slot />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ import { faBirthdayCake, faBuilding, faCaretRight, faEnvelope, faMapMarkerAlt, f
 
 <style>
   body {
-    @apply h-screen font-['Raleway'];
+    @apply h-screen;
   }
 
   @keyframes avatar-fade-in {


### PR DESCRIPTION
Astro Font: https://www.launchfa.st/blog/building-astro-font

# Changes

This PR integrates `astro-font` which automatically generates the fallback font and pass it as the CSS Variable.